### PR TITLE
Support version pinning in Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -41,20 +41,24 @@ if ([string]::IsNullOrEmpty($url)) {
     if($null -eq $version){
       $version = "latest"
     }
-    $releaseInfoUrl = "https://buildkite.com/agent/releases/$($version)?platform=windows&arch=$arch"
-    if($beta) {
-        $releaseInfoUrl = $releaseInfoUrl + "&prerelease=true"
+    if ($version -eq "latest") {
+      $releaseInfoUrl = "https://buildkite.com/agent/releases/$($version)?platform=windows&arch=$arch"
+      if($beta) {
+          $releaseInfoUrl = $releaseInfoUrl + "&prerelease=true"
+      }
+      Write-Host "Finding latest release"
+  
+      $resp = Invoke-WebRequest -Uri "$releaseInfoUrl" -UseBasicParsing -Method GET
+  
+      $releaseInfo = @{}
+      foreach ($line in $resp.Content.Split("`n")) {
+          $info = $line -split "="
+          $releaseInfo.add($info[0],$info[1])
+      }
+      $url = $releaseInfo.url
+    } else {
+      $url = "https://github.com/buildkite/agent/releases/download/v$($version)/buildkite-agent-windows-$arch-$($version).zip"
     }
-    Write-Host "Finding latest release"
-
-    $resp = Invoke-WebRequest -Uri "$releaseInfoUrl" -UseBasicParsing -Method GET
-
-    $releaseInfo = @{}
-    foreach ($line in $resp.Content.Split("`n")) {
-        $info = $line -split "="
-        $releaseInfo.add($info[0],$info[1])
-    }
-    $url = $releaseInfo.url
 }
 
 # Github requires TLS1.2


### PR DESCRIPTION
The [buildkite-agent version comes from the env variable](https://github.com/elastic/buildkite-agent/blob/main/install.ps1#L6) (`$version = $env:buildkiteAgentVersion`) but it's not usable because the URL [here](https://github.com/elastic/buildkite-agent/blob/main/install.ps1#L44) only exists when `version=latest`. Therefore, the fix introduced in this PR skips that URL and downloads the package directly.

Tested ([draft PR](https://github.com/elastic/ci-agent-images/pull/990) in the ci-agent-images):

- [buildkiteAgentVersion unset](https://github.com/elastic/ci-agent-images/pull/990/files/0b930d2609ef1235a29ce8450c3f9e875630f97a): [buildkite](https://buildkite.com/elastic/ci-vm-images/builds/7251)
- [buildkiteAgentVersion = latest](https://github.com/elastic/ci-agent-images/pull/990/files/63d5958fcbf48936939eec582c314c96c8c0196b): [buildkite](https://buildkite.com/elastic/ci-vm-images/builds/7249)
- [buildkiteAgentVersion = 3.76.1](https://github.com/elastic/ci-agent-images/pull/990/files/f90b8e198a47a78682657c05d9ba6bb8d70b737a): [buildkite](https://buildkite.com/elastic/ci-vm-images/builds/7232)
