### PR TITLE
Support version pinning in Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,6 @@ echo -e "\033[33m
                                                 __/ |
                                                |___/\033[0m"
 
-echo -e "Finding latest release..."
-
 SYSTEM="$(uname -s | awk '{print tolower($0)}')"
 MACHINE="$(uname -m | awk '{print tolower($0)}')"
 
@@ -84,6 +82,8 @@ else
 fi
 
 if [[ "${BUILDKITE_AGENT_VERSION:-"latest"}" == "latest" ]]; then
+    echo -e "Finding latest release..."
+
     RELEASE_INFO_URL="https://buildkite.com/agent/releases/latest?platform=${PLATFORM}&arch=${ARCH}&system=${SYSTEM}&machine=${MACHINE}"
     if [[ "${BETA:-}" == "true" ]]; then
       RELEASE_INFO_URL="${RELEASE_INFO_URL}&prerelease=true"

--- a/install.sh
+++ b/install.sh
@@ -73,20 +73,20 @@ else
   esac
 fi
 
+if command -v curl >/dev/null 2>&1 ; then
+  HTTP_GET="curl -LsS"
+elif command -v wget >/dev/null 2>&1 ; then
+  HTTP_GET="wget -qO-"
+else
+  echo -e "\033[31mCouldn't find either curl or wget on the system\!\033[0m\n"
+  echo -e "\033[31mMake sure either curl or wget is installed and findable within \$PATH\!\033[0m\n"
+  exit 1
+fi
+
 if [[ "${BUILDKITE_AGENT_VERSION:-"latest"}" == "latest" ]]; then
     RELEASE_INFO_URL="https://buildkite.com/agent/releases/latest?platform=${PLATFORM}&arch=${ARCH}&system=${SYSTEM}&machine=${MACHINE}"
     if [[ "${BETA:-}" == "true" ]]; then
       RELEASE_INFO_URL="${RELEASE_INFO_URL}&prerelease=true"
-    fi
-
-    if command -v curl >/dev/null 2>&1 ; then
-      HTTP_GET="curl -LsS"
-    elif command -v wget >/dev/null 2>&1 ; then
-      HTTP_GET="wget -qO-"
-    else
-      echo -e "\033[31mCouldn't find either curl or wget on the system\!\033[0m\n"
-      echo -e "\033[31mMake sure either curl or wget is installed and findable within \$PATH\!\033[0m\n"
-      exit 1
     fi
 
     LATEST_RELEASE="$(eval "${HTTP_GET} '${RELEASE_INFO_URL}'")"
@@ -99,7 +99,6 @@ else
     DOWNLOAD_FILENAME="buildkite-agent-${PLATFORM}-${ARCH}-${VERSION}.tar.gz"
     DOWNLOAD_URL="https://github.com/buildkite/agent/releases/download/v${VERSION}/${DOWNLOAD_FILENAME}"
 fi
-
 
 if [[ "${DISABLE_CHECKSUM_VERIFICATION:-}" != "true" ]]; then
   if command -v openssl >/dev/null 2>&1 ; then


### PR DESCRIPTION
Tested:

- BUILDKITE_AGENT_VERSION=3.75.0: [buildkite](https://buildkite.com/elastic/ci-vm-images/builds/7288#0192dcb8-94b9-47b0-bb50-35a06b2effe6/71-673)
- BUILDKITE_AGENT_VERSION=latest: [buildkite](https://buildkite.com/elastic/ci-vm-images/builds/7289#0192dcc5-cc8a-4b07-a05b-db2cb3a43243/71-672)
- No variable set: [buildkite](https://buildkite.com/elastic/ci-vm-images/builds/7290#0192dccc-9495-4898-b4d3-eba31cb7e540/71-672)

The failures are unrelated to the install script.