### PR TITLE
chore: Modified mktemp command for tarball extraction on MacStadium

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,7 @@ fi
 
 mkdir -p "${DESTINATION}/bin"   # for the binary
 mkdir -p "${DESTINATION}/hooks" # for hooks
-INSTALL_TMP="$(mktemp -d -p "${DESTINATION}")" # for tarball extraction
+INSTALL_TMP="$(mktemp -d "${DESTINATION}")" # for tarball extraction
 trap 'rm -fr ${INSTALL_TMP}' EXIT
 
 echo -e "Destination: \033[35m${DESTINATION}\033[0m"

--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,7 @@ fi
 
 mkdir -p "${DESTINATION}/bin"   # for the binary
 mkdir -p "${DESTINATION}/hooks" # for hooks
-INSTALL_TMP="$(mktemp -d "${DESTINATION}")" # for tarball extraction
+INSTALL_TMP="$(mktemp -d "${DESTINATION}/tmp.XXXXXX")" # for tarball extraction
 trap 'rm -fr ${INSTALL_TMP}' EXIT
 
 echo -e "Destination: \033[35m${DESTINATION}\033[0m"


### PR DESCRIPTION
### Description

On MacStadium VMs, the default mktemp is the BSD/macOS version, which does not support the `-p` option. Even on MacStadium, unless you have specifically installed GNU coreutils and are using gmktemp, `mktemp -p` will fail.

This approach is safe and works in both systems, as long as `$DESTINATION` exists and is writable. `tmp.XXXXXX` will create a unique temp directory inside $DESTINATION and avoid the error when the folder already exists.

### Errors

These were the errors encountered before making this change:

- `mktemp: illegal option -- p`
- `mkdtemp failed on /Users/admin/.buildkite-agent: File exists`

### Testing

Tested locally using gobld and a Flavortown pipeline that runs an Orka vm as an step with a newly created custom image that has these changes already (https://buildkite.com/elastic-flavortown/oidc-test/builds/82/steps/canvas?sid=019b6ac0-2a2b-4fa1-ae4e-cefc46b33672).
