### PR TITLE
docs: add AGENTS.md pointer for agent-facing context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+Agent-facing context for this repo lives in [`AGENT.md`](AGENT.md) (build,
+test, and lint commands; architecture map; code style) — this file exists
+alongside it under the `AGENTS.md`/`CLAUDE.md` filename convention that
+agent tooling looks for by default.
+
+This repo is an Elastic-maintained fork of
+[`buildkite/agent`](https://github.com/buildkite/agent), re-pointed at
+Elastic-specific Buildkite CI queues (see `.buildkite/pipeline.yml`).
+`AGENT.md` is shared with upstream — if it goes stale, prefer fixing it
+there over duplicating content into this file.


### PR DESCRIPTION
## What

Adds a root `AGENTS.md` that points to this repo's existing `AGENT.md`
(build/test/lint commands, architecture map, code style) rather than
duplicating its content.

## Why

Flagged by the `ai_repo_ready` readiness audit as gate item **g8**
(`agent_context_exists`) — `not-met`, since no file existed under either
canonical filename (`AGENTS.md`/`CLAUDE.md`) agent tooling looks for by
default. This repo already had a well-formed, accurate `AGENT.md`
(singular) — it just wasn't discoverable under the convention.

## Why a pointer file, not a rename or symlink

- **Not a rename:** `AGENT.md` is shared verbatim with upstream
  [`buildkite/agent`](https://github.com/buildkite/agent) (this repo is a
  fork). Renaming it would diverge from upstream for no benefit.
- **Not a symlink:** this repo builds and tests on Windows CI
  (`.buildkite/pipeline.yml`'s `test-windows` step). Git symlinks aren't
  reliable on Windows checkouts without `core.symlinks=true` and elevated
  permissions — without them, a symlink checks out as a plain text file
  containing only the literal target path string. Separately,
  `gh api repos/.../contents/AGENTS.md`-style reads (what many agents and
  this audit's own tooling use) return a symlink's target path as
  `content`, not the linked file's actual text — which would defeat the
  purpose of this fix for exactly the access pattern it's meant to serve.

A small real file avoids both failure modes.

See `examples/buildkite-agent-scorecard.md` in `elastic/ai_repo_ready` and
`criteria.yaml`'s `g8` entry for the full criterion.